### PR TITLE
[Feat] writeProject 페이지 API 연결 및 디자인 수정

### DIFF
--- a/src/components/Common/Input/index.tsx
+++ b/src/components/Common/Input/index.tsx
@@ -31,8 +31,9 @@ const Input = ({
   const [isFocused, setIsFocused] = useState(false);
 
   // 아이콘 표시 상태 결정
-  const showIconState =
-    !hideIcon && isDuplicateChecked && (error || (!isFocused && !!value.trim()));
+  const showIconState = isDuplicated
+    ? !hideIcon && isDuplicateChecked && (error || (!isFocused && !!value.trim()))
+    : !hideIcon && (error || (!isFocused && !!value.trim()));
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e);

--- a/src/components/Common/Input/styles.ts
+++ b/src/components/Common/Input/styles.ts
@@ -16,6 +16,7 @@ export const StyledInput = styled.input<{
   ${(props) => props.theme.fonts.body4};
   color: ${(props) => props.theme.colors.gray90};
   background-color: ${(props) => props.theme.colors.gray10};
+  height: 4.4rem;
   padding: 1.15rem 1.2rem;
   padding-right: ${(props) =>
     props.$isDuplicated ? '7.6rem' : props.$isPrivateCheckbox ? '8.5rem' : '6.4rem'};
@@ -24,7 +25,6 @@ export const StyledInput = styled.input<{
     ${(props) => (props.$error ? props.theme.colors.coral50 : props.theme.colors.gray20)};
   border-radius: 1.2rem;
   outline: none;
-  box-sizing: border-box;
 
   &:focus {
     border-color: ${(props) =>
@@ -46,8 +46,10 @@ export const StyledInput = styled.input<{
     props.theme.media.pc(
       () => `
       ${props.theme.fonts.body2};
-      padding: 1.4rem 1.6rem;
-      padding-right: ${props.$isDuplicated ? '10rem' : props.$isPrivateCheckbox ? '10.5rem' : '6.4rem'};
+      height: 5.6rem;
+      margin: 0rem;
+      padding: 1.45rem 1.6rem;
+      padding-right: ${props.$isDuplicated ? '10rem' : props.$isPrivateCheckbox ? '10.5rem' : '6.8rem'};
     `
     )}
 `;

--- a/src/components/Common/TextArea/styles.ts
+++ b/src/components/Common/TextArea/styles.ts
@@ -19,7 +19,6 @@ export const StyledTextArea = styled.textarea<{ $error: boolean }>`
   border-radius: 1.2rem;
   resize: none;
   outline: none;
-  box-sizing: border-box;
   overflow: hidden;
 
   &:focus {
@@ -39,7 +38,7 @@ export const StyledTextArea = styled.textarea<{ $error: boolean }>`
     )}
   ${(props) =>
     props.theme.media.pc(css`
-      padding: 1.4rem 1.6rem;
+      padding: 1.45rem 1.6rem;
       padding-right: 6.8rem;
     `)}
 `;

--- a/src/components/FormField/CategorySection/styles.ts
+++ b/src/components/FormField/CategorySection/styles.ts
@@ -26,7 +26,8 @@ export const DropdownHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   flex: 1;
-  padding: 0.8rem 1.2rem;
+  max-height: 4.4rem;
+  padding: 0.85rem 1.2rem;
   border: 0.1rem solid ${(props) => props.theme.colors.gray20};
   border-radius: 1.2rem;
   background-color: ${(props) => props.theme.colors.gray10};
@@ -35,6 +36,7 @@ export const DropdownHeader = styled.div`
 
   ${(props) =>
     props.theme.media.pc(css`
+      max-height: 5.6rem;
       padding: 1.45rem 1.6rem;
     `)}
 `;

--- a/src/components/WriteProject/ImageSection/index.tsx
+++ b/src/components/WriteProject/ImageSection/index.tsx
@@ -7,12 +7,12 @@ import { useState, useRef, useEffect } from 'react';
 import { useResponsive } from '@/hooks/useResponsive';
 
 interface ImageSectionProps {
-  setFormData: React.Dispatch<React.SetStateAction<FormData | null>>;
+  images: File[];
+  setImages: React.Dispatch<React.SetStateAction<File[]>>;
 }
 
-const ImageSection = ({ setFormData }: ImageSectionProps) => {
+const ImageSection = ({ images, setImages }: ImageSectionProps) => {
   const [imagePreviews, setImagePreviews] = useState<string[]>([]);
-  const [imageFiles, setImageFiles] = useState<File[]>([]);
   const [replaceIndex, setReplaceIndex] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -25,7 +25,7 @@ const ImageSection = ({ setFormData }: ImageSectionProps) => {
 
     if (replaceIndex !== null && files.length > 0) {
       // 특정 인덱스의 이미지를 교체
-      const updatedFiles = [...imageFiles];
+      const updatedFiles = [...images];
       const newFile = files[0];
       updatedFiles[replaceIndex] = newFile;
 
@@ -39,13 +39,12 @@ const ImageSection = ({ setFormData }: ImageSectionProps) => {
       };
       reader.readAsDataURL(newFile);
 
-      setImageFiles(updatedFiles);
-      setFormData(createFormData(updatedFiles)); // formdata 형식으로 만들어서 상위 컴포넌트로 전달
+      setImages(updatedFiles);
       setReplaceIndex(null); // 교체 후 초기화
     } else {
       // 새로 추가된 파일 처리
-      const newFiles = [...imageFiles, ...files].slice(0, 10);
-      newFiles.slice(imageFiles.length).forEach((file) => {
+      const newFiles = [...images, ...files].slice(0, 10);
+      newFiles.slice(images.length).forEach((file) => {
         const reader = new FileReader();
         reader.onloadend = () => {
           if (reader.result) {
@@ -55,26 +54,17 @@ const ImageSection = ({ setFormData }: ImageSectionProps) => {
         reader.readAsDataURL(file);
       });
 
-      setImageFiles(newFiles);
-      setFormData(createFormData(newFiles)); // formdata 형식으로 만들어서 상위 컴포넌트로 전달
+      setImages(newFiles);
     }
 
     e.target.value = ''; // 사진 input 초기화
   };
 
-  // formData 생성 함수
-  const createFormData = (files: File[]) => {
-    const formData = new FormData();
-    files.forEach((file) => formData.append('file[]', file));
-    return formData;
-  };
-
   // 이미지 삭제
   const handleRemoveImage = (index: number) => {
-    const updatedFiles = imageFiles.filter((_, i) => i !== index);
+    const updatedFiles = images.filter((_, i) => i !== index);
     setImagePreviews((prev) => prev.filter((_, i) => i !== index));
-    setImageFiles(updatedFiles);
-    setFormData(createFormData(updatedFiles)); // formdata 형식으로 만들어서 상위 컴포넌트로 전달
+    setImages(updatedFiles);
   };
 
   // Change 버튼 클릭 시 인덱스 설정 후 input 클릭하여 파일 선택 창 열기
@@ -110,7 +100,7 @@ const ImageSection = ({ setFormData }: ImageSectionProps) => {
             <S.StyledImg src={preview} alt={`사진${index}`} />
           </S.ImageContainer>
         ))}
-        {imageFiles.length < 10 && (
+        {images.length < 10 && (
           <>
             <S.UploadBtn
               $backgroundImage={isPC ? imageUploadPCBtn : imageUploadBtn}

--- a/src/components/WriteProject/LinkSection/index.tsx
+++ b/src/components/WriteProject/LinkSection/index.tsx
@@ -63,7 +63,7 @@ const LinkSection = ({ links, setLinks }: LinkSectionProps) => {
   return (
     <S.SectionContainer>
       <S.SectionTitle>링크</S.SectionTitle>
-      <S.LinkInputContainer>
+      <S.LinkInputContainer $hasLinks={Object.keys(links).length > 0}>
         {Object.entries(links).map(([title, url], index) => (
           <S.Link key={index}>
             <S.LinkIcon $backgroundImage={linkIcon} />

--- a/src/components/WriteProject/LinkSection/index.tsx
+++ b/src/components/WriteProject/LinkSection/index.tsx
@@ -21,12 +21,7 @@ const LinkSection = ({ links, setLinks }: LinkSectionProps) => {
       const trimmedValue = inputValue.trim();
       if (trimmedValue && !Object.values(links).includes(trimmedValue)) {
         try {
-          const accessToken = localStorage.getItem('access');
-          const response = await instance.post(
-            '/pofolo/projects/links/',
-            { link: trimmedValue },
-            { headers: { Authorization: `Bearer ${accessToken}` } }
-          );
+          const response = await instance.post('/pofolo/projects/links/', { link: trimmedValue });
           setLinks((prevLinks) => ({
             ...prevLinks,
             [response.data.title]: trimmedValue,

--- a/src/components/WriteProject/LinkSection/index.tsx
+++ b/src/components/WriteProject/LinkSection/index.tsx
@@ -2,22 +2,39 @@ import * as S from '@/components/WriteProject/LinkSection/styles';
 import { useState, KeyboardEvent, ChangeEvent } from 'react';
 import linkIcon from '@/assets/webps/Common/link.webp';
 import linkDeleteIcon from '@/assets/webps/Common/linkDelete.webp';
+import { instance } from '@/apis/instance';
+
+interface SiteLink {
+  [key: string]: string;
+}
 
 interface LinkSectionProps {
-  links: string[];
-  setLink: React.Dispatch<React.SetStateAction<string[]>>;
+  links: SiteLink;
+  setLinks: React.Dispatch<React.SetStateAction<SiteLink>>;
 }
-const LinkSection = ({ links = [], setLink }: LinkSectionProps) => {
+const LinkSection = ({ links, setLinks }: LinkSectionProps) => {
   const [inputValue, setInputValue] = useState<string>('');
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === ',' && e.nativeEvent.isComposing === false) {
       e.preventDefault();
       const trimmedValue = inputValue.trim();
-      if (trimmedValue && !links.includes(trimmedValue)) {
-        // 링크 중복 등록 안되게
-        setLink([...links, trimmedValue]);
-        setInputValue('');
+      if (trimmedValue && !Object.values(links).includes(trimmedValue)) {
+        try {
+          const accessToken = localStorage.getItem('access');
+          const response = await instance.post(
+            '/pofolo/projects/links/',
+            { link: trimmedValue },
+            { headers: { Authorization: `Bearer ${accessToken}` } }
+          );
+          setLinks((prevLinks) => ({
+            ...prevLinks,
+            [response.data.title]: trimmedValue,
+          }));
+          setInputValue('');
+        } catch (error) {
+          console.error(error);
+        }
       }
     }
   };
@@ -31,8 +48,12 @@ const LinkSection = ({ links = [], setLink }: LinkSectionProps) => {
     }
   };
 
-  const handleRemoveLink = (index: number) => {
-    setLink(links.filter((_, i) => i !== index));
+  const handleRemoveLink = (key: string) => {
+    setLinks((prevLinks) => {
+      const updatedLinks = { ...prevLinks };
+      delete updatedLinks[key];
+      return updatedLinks;
+    });
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -43,16 +64,16 @@ const LinkSection = ({ links = [], setLink }: LinkSectionProps) => {
     <S.SectionContainer>
       <S.SectionTitle>링크</S.SectionTitle>
       <S.LinkInputContainer>
-        {links.map((link, index) => (
+        {Object.entries(links).map(([title, url], index) => (
           <S.Link key={index}>
             <S.LinkIcon $backgroundImage={linkIcon} />
             <S.LinkContentContainer>
-              <S.LinkTitle>{link}</S.LinkTitle>
-              <S.LinkDomain>{getDomainFromUrl(link)}</S.LinkDomain>
+              <S.LinkTitle>{title}</S.LinkTitle>
+              <S.LinkDomain>{getDomainFromUrl(url)}</S.LinkDomain>
             </S.LinkContentContainer>
             <S.RemoveButton
               $backgroundImage={linkDeleteIcon}
-              onClick={() => handleRemoveLink(index)}
+              onClick={() => handleRemoveLink(title)}
             />
           </S.Link>
         ))}
@@ -61,7 +82,9 @@ const LinkSection = ({ links = [], setLink }: LinkSectionProps) => {
           value={inputValue}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          placeholder={links.length ? '' : '관련된 외부 링크를 추가하세요 (쉼표로 구분)'}
+          placeholder={
+            Object.keys(links).length === 0 ? '관련된 외부 링크를 추가하세요 (쉼표로 구분)' : ''
+          }
         />
       </S.LinkInputContainer>
     </S.SectionContainer>

--- a/src/components/WriteProject/LinkSection/styles.ts
+++ b/src/components/WriteProject/LinkSection/styles.ts
@@ -4,6 +4,7 @@ export const LinkInputContainer = styled.div`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  height: 4.4rem;
   padding: 0.8rem;
   border: 0.1rem solid ${(props) => props.theme.colors.gray20};
   border-radius: 1.2rem;
@@ -15,8 +16,13 @@ export const LinkInputContainer = styled.div`
 
   ${(props) =>
     props.theme.media.pc(css`
+      height: 5.6rem;
       padding: 1.4rem;
     `)}
+
+  &:focus-within {
+    border-color: ${(props) => props.theme.colors.blue50};
+  }
 `;
 
 export const Link = styled.div`

--- a/src/components/WriteProject/LinkSection/styles.ts
+++ b/src/components/WriteProject/LinkSection/styles.ts
@@ -1,24 +1,25 @@
 import styled, { css } from 'styled-components';
 
-export const LinkInputContainer = styled.div`
+export const LinkInputContainer = styled.div<{ $hasLinks: boolean }>`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  height: 4.4rem;
   padding: 0.8rem;
   border: 0.1rem solid ${(props) => props.theme.colors.gray20};
   border-radius: 1.2rem;
   background-color: ${(props) => props.theme.colors.gray10};
   gap: 1.2rem 1.8rem;
   width: 100%;
+  height: ${(props) => (props.$hasLinks ? 'auto' : '4.4rem')};
   min-width: 0;
-  min-height: 4.4rem;
 
   ${(props) =>
-    props.theme.media.pc(css`
-      height: 5.6rem;
+    props.theme.media.pc(
+      () => `
       padding: 1.4rem;
-    `)}
+      height: ${props.$hasLinks ? 'auto' : '5.6rem'};
+    `
+    )}
 
   &:focus-within {
     border-color: ${(props) => props.theme.colors.blue50};

--- a/src/pages/Login/Join/styles.ts
+++ b/src/pages/Login/Join/styles.ts
@@ -198,13 +198,13 @@ export const DuplicationBtn = styled.div`
 
   ${(props) =>
     props.theme.media.ph(css`
-      top: 7.7rem;
+      top: 7.55rem;
       right: 7.2rem;
     `)}
 
   ${(props) =>
     props.theme.media.tab(css`
-      top: 7.1rem;
+      top: 7rem;
       right: 2.8rem;
     `)}
 `;
@@ -247,22 +247,22 @@ export const NextBtn = styled.div<{
     props.theme.media.ph(css`
       left: 27.6rem;
       top: 6.4rem;
-      width: 4.6rem;
-      height: 4.6rem;
+      width: 4.4rem;
+      height: 4.4rem;
     `)}
 
   ${(props) =>
     props.theme.media.tab(css`
       left: 57.6rem;
       top: 6.4rem;
-      width: 4.6rem;
-      height: 4.6rem;
+      width: 4.4rem;
+      height: 4.4rem;
     `)}
 `;
 
 export const PrivateCheckbox = styled.div`
   position: absolute;
-  top: 7.4rem;
+  top: 7.3rem;
   right: 3.2rem;
   display: flex;
   align-items: center;
@@ -270,7 +270,7 @@ export const PrivateCheckbox = styled.div`
 
   ${(props) =>
     props.theme.media.pc(css`
-      top: 7.8rem;
+      top: 7.7rem;
       right: 4.2rem;
       gap: 0.8rem;
     `)}

--- a/src/pages/Project/WriteProjectPage/index.tsx
+++ b/src/pages/Project/WriteProjectPage/index.tsx
@@ -8,8 +8,14 @@ import LinkSection from '@/components/WriteProject/LinkSection';
 import ImageSection from '@/components/WriteProject/ImageSection';
 import Navbar from '@/components/Layout/Navbar/Navbar';
 import Modal from '@/components/Common/Modal';
+import { instance } from '@/apis/instance';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useResponsive } from '@/hooks/useResponsive';
+
+interface SiteLink {
+  [key: string]: string;
+}
 
 export const WriteProjectPage = () => {
   const [isPrivate, setIsPrivate] = useState<boolean>(false);
@@ -18,17 +24,18 @@ export const WriteProjectPage = () => {
   const [subCategory, setSubCategory] = useState<string>('');
   const [description, setDescription] = useState<string>('');
   const [skill, setSkill] = useState<string>('');
-  const [links, setLinks] = useState<string[]>([]);
-  const [formData, setFormData] = useState<FormData | null>(null);
+  const [links, setLinks] = useState<SiteLink>({});
+  const [images, setImages] = useState<File[]>([]);
   const [errors, setErrors] = useState<Record<string, boolean>>({
     title: false,
     description: false,
     category: false,
   });
-
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isAlertModalOpen, setIsAlertModalOpen] = useState<boolean>(false);
+  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState<boolean>(false);
   const [pendingAction, setPendingAction] = useState<null | (() => void)>(null); // 실행할 함수 임시 저장
   const navigate = useNavigate();
+  const { isPC } = useResponsive();
 
   // 필수 입력 항목 유효성 검사 -> 에러 설정
   const validateFields = () => {
@@ -47,24 +54,44 @@ export const WriteProjectPage = () => {
     !!mainCategory &&
     !!subCategory;
 
+  const uploadData = async (isPrivateOverride?: boolean) => {
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('description', description);
+    formData.append('major_field', mainCategory);
+    formData.append('sub_field', subCategory);
+    formData.append('skills', skill);
+    formData.append('links', JSON.stringify(links));
+
+    const isPublic = isPrivateOverride ? 'false' : isPrivate ? 'false' : 'true';
+    formData.append('is_public', isPublic);
+    for (let i = 0; i < images.length; i++) {
+      formData.append('project_img', images[i]);
+    }
+
+    try {
+      const accessToken = localStorage.getItem('access');
+      const response = await instance.post('/pofolo/projects/create/', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      setPendingAction(() => () => {
+        navigate(`/project/${response.data.id}`); // navigate 함수를 저장했다가 '프로젝트 보기' 클릭 시 넘어감
+      });
+      setIsCompleteModalOpen(true);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   // 업로드 버튼을 누르면 유효성 검사 실시 -> 에러 설정, 버튼이 활성화 되어있는 경우 업로드 처리 로직
-  const handleUploadClick = () => {
+  const handleUploadClick = async () => {
     validateFields();
 
     if (btnActive) {
-      // 사진 처리
-      const data = {
-        isPrivate,
-        title,
-        mainCategory,
-        subCategory,
-        description,
-        skill,
-        links,
-        // 사진 url
-      };
-      console.log('업로드 처리', data);
-      // 페이지 이동
+      uploadData();
     }
   };
 
@@ -74,8 +101,8 @@ export const WriteProjectPage = () => {
       title.trim() ||
       description.trim() ||
       skill.trim() ||
-      links.length > 0 ||
-      (formData && Array.from(formData.entries()).length > 0) ||
+      Object.keys(links).length > 0 ||
+      (images && Array.from(images.entries()).length > 0) ||
       mainCategory ||
       subCategory
     );
@@ -88,7 +115,6 @@ export const WriteProjectPage = () => {
       event.returnValue = '';
     }
   };
-
   useEffect(() => {
     window.addEventListener('beforeunload', handleBeforeUnload);
 
@@ -100,7 +126,7 @@ export const WriteProjectPage = () => {
   // 모달 열기
   const openModal = (action: () => void) => {
     setPendingAction(() => action);
-    setIsModalOpen(true);
+    setIsAlertModalOpen(true);
   };
 
   // 네비게이션 함수
@@ -124,35 +150,30 @@ export const WriteProjectPage = () => {
     }
   };
 
-  // 모달에서 나가기 버튼 클릭
-  const handleModalExit = () => {
+  // 경고 모달에서 나가기 버튼 클릭
+  const handleAlertModalExit = () => {
     window.removeEventListener('beforeunload', handleBeforeUnload); // 모달에서 나가기 클릭할때는 beforeunload 이벤트 제거
     if (pendingAction) {
       pendingAction(); // 임시 저장 함수 실행
     }
-    setIsModalOpen(false);
+    setIsAlertModalOpen(false);
   };
 
-  // 모달에서 비공개 업로드 버튼 클릭
-  const handleModalPrivateUpload = () => {
-    setIsModalOpen(false);
+  // 경고 모달에서 비공개 업로드 버튼 클릭
+  const handleAlertModalPrivateUpload = () => {
+    setIsAlertModalOpen(false);
     setIsPrivate(true);
     validateFields();
+
     if (btnActive) {
-      // 사진 처리
-      const data = {
-        isPrivate: true,
-        title,
-        mainCategory,
-        subCategory,
-        description,
-        skill,
-        links,
-        // 사진 url
-      };
-      console.log('업로드 처리', data);
-      // 페이지 이동
+      uploadData(true);
     }
+  };
+
+  // 프로젝트 완성 모달에서 닫기 버튼 클릭
+  const handleCompleteModalClose = () => {
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+    navigate(-1);
   };
 
   return (
@@ -186,6 +207,7 @@ export const WriteProjectPage = () => {
               setSubcategory={setSubCategory}
               error={errors.category}
               setErrors={setErrors}
+              direction={isPC ? 'row' : 'column'}
             />
             <DescriptionSection
               description={description}
@@ -194,21 +216,35 @@ export const WriteProjectPage = () => {
               setErrors={setErrors}
             />
             <SkillSection skill={skill} setSkill={setSkill} />
-            <LinkSection links={links} setLink={setLinks} />
-            <ImageSection setFormData={setFormData} />
+            <LinkSection links={links} setLinks={setLinks} />
+            <ImageSection images={images} setImages={setImages} />
           </S.FormContainer>
         </S.PortFolioLayout>
       </S.Layout>
       <Modal
-        isOpen={isModalOpen}
-        setIsOpen={setIsModalOpen}
+        isOpen={isAlertModalOpen}
+        setIsOpen={setIsAlertModalOpen}
         icon="warning"
         mainText="작성 중인 글이 있어요"
         subText={`지금 나가면 작성 중인 내용이 모두 사라져요.\n비공개로 업로드하고 언제든지 수정하세요.`}
         LBtnText="나가기"
-        LBtnOnClick={handleModalExit}
+        LBtnOnClick={handleAlertModalExit}
         RBtnText="비공개 업로드"
-        RBtnOnclick={handleModalPrivateUpload}
+        RBtnOnclick={handleAlertModalPrivateUpload}
+      />
+      <Modal
+        isOpen={isCompleteModalOpen}
+        setIsOpen={setIsCompleteModalOpen}
+        icon="checked"
+        mainText="프로젝트가 완성되었어요!"
+        LBtnText="닫기"
+        LBtnOnClick={handleCompleteModalClose}
+        RBtnText="프로젝트 보기"
+        RBtnOnclick={() => {
+          if (pendingAction) {
+            pendingAction();
+          }
+        }}
       />
     </>
   );


### PR DESCRIPTION
## 📎 작업 내용
### ✨ 프로젝트 작성 페이지 API 연결
- 링크 title 반환 API, 프로젝트 생성 API 연결했습니다.
- 업로드 버튼을 누르면 모달이 뜨고, '닫기'를 누르면 이전페이지로, '프로젝트 보기'를 누르면 프로젝트 상세 조회 페이지로 넘어가도록 했습니다.

### ✨ input, textarea, 드롭다운, 링크 입력창 높이 설정 및 일부 디자인 수정
- 입력창을 padding으로 맞췄더니 높이가 조금씩 달라서 모든 입력창의 height를 pc일때 5.6rem, 모바일일때 4.4rem으로 설정했습니다.
- join 페이지에서 바뀐 input에 맞춰 중복 확인 버튼과 비공개 체크박스 위치 조금씩 수정했습니다. 괜찮은지 확인 부탁드려요! @letthem 
- 링크 입력창도 focus 되었을 때 테두리가 파란색으로 변하도록 수정했습니다.

### ❕ 공통
- input, textarea 디자인 변경 확인해주세요
- 기본 input에서 아이콘이 보이지 않는 오류가 있어서 아래와 같이 아이콘 표시 조건을 수정했습니다. 
  isDuplicated가 true일때 (중복확인을 하는 input창일 경우)만 isDuplicateChecked 조건을 추가로 확인하도록 했습니다.
  ```typescript
  // 아이콘 표시 상태 결정
  const showIconState = isDuplicated
    ? !hideIcon && isDuplicateChecked && (error || (!isFocused && !!value.trim()))
    : !hideIcon && (error || (!isFocused && !!value.trim()));
   ```
  이것도 확인해주세용 .. @letthem 

## 📎 작업 화면 스크린샷
> ### 업로드 시 모달
<img width="947" alt="image" src="https://github.com/user-attachments/assets/d27e53b6-f9bd-41d7-9001-2eec45ec60f9" />


---
>### join 페이지 입력창
<img width="628" alt="image" src="https://github.com/user-attachments/assets/7acd44de-168b-499c-acf8-796aa8cd3cbd" />
<br/>
<img width="488" alt="image" src="https://github.com/user-attachments/assets/708b46f6-e3c6-486e-a9f3-d0b28fac4160" />
<br/>
<img width="257" alt="image" src="https://github.com/user-attachments/assets/a5b523a2-bfa8-4316-9f94-bff1f1cb3bbf" />
<br/>
<img width="615" alt="image" src="https://github.com/user-attachments/assets/63246812-5c9a-4029-bcb9-c5927557d5da" />
<br/>
<img width="471" alt="image" src="https://github.com/user-attachments/assets/740aeb23-890e-4958-8c38-9d4dd4c0e9c6" />
<br/>
<img width="251" alt="image" src="https://github.com/user-attachments/assets/1196a016-af4c-41ad-8590-96658f098021" />





---